### PR TITLE
Add Higher Order Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,29 @@
 npm install reactcss --save
 ```
 
-### Extend ReactCSS
+### Extend ReactCSS or Use Higher Order Component
+
+#### Extend ReactCSS
 ```javascript
 var ReactCSS = require('reactcss');
 
 class Button extends ReactCSS.Component {
   ...
 }
+```
+
+#### Use Higher Order Component
+```javascript
+var ReactCSS = require('reactcss');
+
+class Button extends React.Component {
+  styles() {
+    return this.props.css(this.classes())
+  }
+
+  ...
+}
+const StyledButton = ReactCss.useStyles(Button)
 ```
 
 ### Put in a Default Class

--- a/examples/Button.hoc.jsx
+++ b/examples/Button.hoc.jsx
@@ -1,0 +1,64 @@
+'use strict';
+
+const React = require('react');
+const ReactCSS = require('reactcss');
+
+class Button extends ReactCSS.Component {
+
+  constructor() {
+    super();
+
+    // Set a fallback backgound and color if one isnt specified
+    this.defaultProps = {
+      background: '#4A90E2',
+      color: 'rgba(255,255,255,.87)',
+    };
+  }
+
+  // Add this method to connect to RectCSS styles
+  styles() {
+    return this.props.css(this.classes());
+  }
+
+  classes() {
+    return {
+      // This is our default button class
+      'default': {
+        button: {
+          background: this.props.background,
+          display: 'inline-block',
+          height: '44px',
+          lineHeight: '44px',
+          borderRadius: '2px',
+        },
+        span: {
+          color: this.props.color,
+          padding: '0 14px',
+        },
+      },
+
+      // This class activates when `disabled: true` is passed as props
+      'disabled-true': {
+        button: {
+          background: '#ccc',
+        },
+        span: {
+          color: '#aaa',
+        },
+      },
+    };
+  }
+
+  render() {
+    return (
+
+      // You will notice the is syntax here, via `react-map-styles` package
+      // This handles mapping the styles to the elements
+      <div is="button">
+        <span is="span">{ this.props.label }</span>
+      </div>
+    );
+  }
+}
+
+export default ReactCSS.useStyles(Button);

--- a/examples/Dialog.hoc.jsx
+++ b/examples/Dialog.hoc.jsx
@@ -1,0 +1,84 @@
+'use strict';
+
+const React = require('react');
+const ReactCSS = require('reactcss');
+
+const Button = require('./Button.hoc');
+
+class Dialog extends React.Component {
+
+  // Add this method to connect to RectCSS styles
+  styles() {
+    return this.props.css(this.classes());
+  }
+
+  classes() {
+    return {
+      // This is our default dialog class
+      'default': {
+        dialog: {
+          background: '#fff',
+          boxShadow: '0 6px 20px rgba(0,0,0,.19), 0 8px 17px rgba(0,0,0,.2)',
+          borderRadius: '2px',
+          maxWidth: '400px',
+        },
+        body: {
+          padding: '24px',
+        },
+        title: {
+          fontSize: '20px',
+          fontWeight: '500',
+          paddingBottom: '20px',
+          color: 'rgba(0,0,0,.87)',
+        },
+        desc: {
+          fontSize: '17px',
+          lineHeight: '22px',
+          color: 'rgba(0,0,0,.47)',
+          margin: '0',
+        },
+        actions: {
+          margin: '0',
+          padding: '8px',
+          display: 'flex',
+          justifyContent: 'flex-end',
+          listStyleType: 'none',
+        },
+        button: {
+          marginLeft: '8px',
+        },
+        CancelButton: {
+          background: 'red',
+        },
+      },
+
+      // This class activates when `disabled: true` is passed as props
+      'disabled-true': {
+        AgreeButton: {
+          disabled: true,
+        },
+      },
+    };
+  }
+
+  render() {
+    return (
+
+      // You will notice the is syntax here, via `react-map-styles` package
+      // This handles mapping the styles to the elements
+      <div is="dialog">
+        <div is="body">
+          <div is="title">{ this.props.title }</div>
+          <p is="desc">{ this.props.description }</p>
+        </div>
+        <ul is="actions">
+          <li is="button"><Button is="CancelButton" label="Cancel" /></li>
+          <li is="button"><Button is="AgreeButton" label="Yes, I Agree" /></li>
+        </ul>
+      </div>
+    );
+  }
+}
+
+// Create higher-order component to add 'getStyle' to props
+export default ReactCSS.useStyles(Dialog);

--- a/lib/Component.js
+++ b/lib/Component.js
@@ -1,26 +1,48 @@
 'use strict';
 
-const React = require('react');
-const inline = require('./inline');
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-class ReactCSSComponent extends React.Component {
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-  css(obj) {
-    if (!this.classes) {
-      console.warn(`Define this.classes on \`${ this.constructor.name }\``);
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var React = require('react');
+var inline = require('./inline');
+
+var ReactCSSComponent = function (_React$Component) {
+  _inherits(ReactCSSComponent, _React$Component);
+
+  function ReactCSSComponent() {
+    _classCallCheck(this, ReactCSSComponent);
+
+    return _possibleConstructorReturn(this, Object.getPrototypeOf(ReactCSSComponent).apply(this, arguments));
+  }
+
+  _createClass(ReactCSSComponent, [{
+    key: 'css',
+    value: function css(obj) {
+      if (!this.classes) {
+        console.warn('Define this.classes on `' + this.constructor.name + '`');
+      }
+      var classes = typeof this.classes === 'function' ? this.classes() : {};
+
+      return inline(classes, this.props, this.context.mixins, obj);
     }
-    const classes = typeof this.classes === 'function' ? this.classes() : {};
+  }, {
+    key: 'styles',
+    value: function styles() {
+      return this.css();
+    }
+  }]);
 
-    return inline(classes, this.props, this.context.mixins, obj);
-  }
-
-  styles() {
-    return this.css();
-  }
-
-}
+  return ReactCSSComponent;
+}(React.Component);
 
 // For New Mixins
+
+
 ReactCSSComponent.contextTypes = {
   mixins: React.PropTypes.object
 };

--- a/lib/check-class-structure.js
+++ b/lib/check-class-structure.js
@@ -1,19 +1,19 @@
 'use strict';
 
-const isObject = require('lodash.isobject');
+var isObject = require('lodash.isobject');
 
-module.exports = classes => {
+module.exports = function (classes) {
 
   for (var className in classes) {
     var elements = classes[className];
     if (!isObject(elements)) {
-      console.warn(`Make sure the value of \`${ className }\` is an object of html elements. You passed it \`${ elements }\``);
+      console.warn('Make sure the value of `' + className + '` is an object of html elements. You passed it `' + elements + '`');
     } else {
 
       for (var elementName in elements) {
         var css = elements[elementName];
         if (!isObject(css)) {
-          console.warn(`Make sure the value of the element \`${ className }\` is an object of css. You passed it \`${ elements }\``);
+          console.warn('Make sure the value of the element `' + className + '` is an object of css. You passed it `' + elements + '`');
         }
       }
     }

--- a/lib/check-class-structure.js
+++ b/lib/check-class-structure.js
@@ -1,1 +1,21 @@
-"use strict";var isObject=require("lodash.isobject");module.exports=function(e){for(var s in e){var o=e[s];if(isObject(o))for(var t in o){var a=o[t];isObject(a)||console.warn("Make sure the value of the element `"+s+"` is an object of css. You passed it `"+o+"`")}else console.warn("Make sure the value of `"+s+"` is an object of html elements. You passed it `"+o+"`")}};
+'use strict';
+
+const isObject = require('lodash.isobject');
+
+module.exports = classes => {
+
+  for (var className in classes) {
+    var elements = classes[className];
+    if (!isObject(elements)) {
+      console.warn(`Make sure the value of \`${ className }\` is an object of html elements. You passed it \`${ elements }\``);
+    } else {
+
+      for (var elementName in elements) {
+        var css = elements[elementName];
+        if (!isObject(css)) {
+          console.warn(`Make sure the value of the element \`${ className }\` is an object of css. You passed it \`${ elements }\``);
+        }
+      }
+    }
+  }
+};

--- a/lib/combine.js
+++ b/lib/combine.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const merge = require('./merge-classes');
-const mixins = require('./transform-mixins');
+var merge = require('./merge-classes');
+var mixins = require('./transform-mixins');
 
-module.exports = (styles, customMixins) => {
-  const merged = merge(styles);
+module.exports = function (styles, customMixins) {
+  var merged = merge(styles);
   return mixins(merged, customMixins);
 };

--- a/lib/combine.js
+++ b/lib/combine.js
@@ -1,1 +1,9 @@
-"use strict";var merge=require("./merge-classes"),mixins=require("./transform-mixins");module.exports=function(e,r){var i=merge(e);return mixins(i,r)};
+'use strict';
+
+const merge = require('./merge-classes');
+const mixins = require('./transform-mixins');
+
+module.exports = (styles, customMixins) => {
+  const merged = merge(styles);
+  return mixins(merged, customMixins);
+};

--- a/lib/inline.js
+++ b/lib/inline.js
@@ -1,1 +1,74 @@
-"use strict";var isObject=require("lodash.isobject"),checkClassStructure=require("./check-class-structure"),combine=require("./combine");module.exports=function(s){var e=this;combine=require("./combine");var t=[];this.classes||console.warn("Define this.classes on `"+this.constructor.name+"`"),checkClassStructure(this.classes&&this.classes());var r=function(s,r){e.classes&&e.classes()[s]?t.push(e.classes()[s]):s&&r&&r.warn===!0&&console.warn("The `"+s+"` css class does not exist on `"+e.constructor.name+"`")};r("default");for(var c in this.props){var i=this.props[c];isObject(i)||(i===!0?(r(c),r(c+"-true")):r(i?c+"-"+i:c+"-false"))}if(this.props&&this.props.activeBounds)for(var o=0;o<this.props.activeBounds.length;o++){var n=this.props.activeBounds[o];r(n)}for(var a in s){var u=s[a];u===!0&&r(a,{warn:!0})}var h={};return this.context&&this.context.mixins&&(h=this.context.mixins),combine(t,h)};
+'use strict';
+
+const isObject = require('lodash.isobject');
+const checkClassStructure = require('./check-class-structure');
+let combine = require('./combine');
+
+/*
+  Inline CSS function. This is the half-way point until multiple inheritance exists
+
+  @param classes: The classes to use
+  @param props: The props of the component the styles are being used by
+  @param customMixins: The css mixins to use
+  @param declaredClasses: Object{ 'class-name': true / false }
+
+  @returns object
+*/
+module.exports = (classes, props, customMixins, declaredClasses) => {
+  // What?
+  combine = require('./combine');
+
+  const arrayOfStyles = [];
+
+  // Checks structure and warns if its odd
+  checkClassStructure(classes);
+
+  const activateClass = (name, options) => {
+    if (classes && classes[name]) {
+      arrayOfStyles.push(classes[name]);
+    } else if (name && options && options.warn === true) {
+      console.warn(`The \`${ name }\` css class does not exist`);
+    }
+  };
+
+  activateClass('default');
+
+  if (props) {
+    for (let prop in props) {
+      let value = props[prop];
+      if (!isObject(value)) {
+
+        if (value === true) {
+          activateClass(prop);
+          activateClass(`${ prop }-true`);
+        } else if (value) {
+          activateClass(`${ prop }-${ value }`);
+        } else {
+          activateClass(`${ prop }-false`);
+        }
+      }
+    }
+
+    // React Bounds
+    // http://casesandberg.github.io/react-bounds/
+    // Activate classes that match active bounds
+    if (props.activeBounds) {
+      for (let i = 0; i < props.activeBounds.length; i++) {
+        const boundName = props.activeBounds[i];
+        activateClass(boundName);
+      }
+    }
+  }
+
+  if (declaredClasses) {
+    for (let name in declaredClasses) {
+      let condition = declaredClasses[name];
+
+      if (condition === true) {
+        activateClass(name, { warn: true });
+      }
+    }
+  }
+
+  return combine(arrayOfStyles, customMixins ? customMixins : {});
+};

--- a/lib/inline.js
+++ b/lib/inline.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const isObject = require('lodash.isobject');
-const checkClassStructure = require('./check-class-structure');
-let combine = require('./combine');
+var isObject = require('lodash.isobject');
+var checkClassStructure = require('./check-class-structure');
+var combine = require('./combine');
 
 /*
   Inline CSS function. This is the half-way point until multiple inheritance exists
@@ -14,37 +14,37 @@ let combine = require('./combine');
 
   @returns object
 */
-module.exports = (classes, props, customMixins, declaredClasses) => {
+module.exports = function (classes, props, customMixins, declaredClasses) {
   // What?
   combine = require('./combine');
 
-  const arrayOfStyles = [];
+  var arrayOfStyles = [];
 
   // Checks structure and warns if its odd
   checkClassStructure(classes);
 
-  const activateClass = (name, options) => {
+  var activateClass = function activateClass(name, options) {
     if (classes && classes[name]) {
       arrayOfStyles.push(classes[name]);
     } else if (name && options && options.warn === true) {
-      console.warn(`The \`${ name }\` css class does not exist`);
+      console.warn('The `' + name + '` css class does not exist');
     }
   };
 
   activateClass('default');
 
   if (props) {
-    for (let prop in props) {
-      let value = props[prop];
+    for (var prop in props) {
+      var value = props[prop];
       if (!isObject(value)) {
 
         if (value === true) {
           activateClass(prop);
-          activateClass(`${ prop }-true`);
+          activateClass(prop + '-true');
         } else if (value) {
-          activateClass(`${ prop }-${ value }`);
+          activateClass(prop + '-' + value);
         } else {
-          activateClass(`${ prop }-false`);
+          activateClass(prop + '-false');
         }
       }
     }
@@ -53,16 +53,16 @@ module.exports = (classes, props, customMixins, declaredClasses) => {
     // http://casesandberg.github.io/react-bounds/
     // Activate classes that match active bounds
     if (props.activeBounds) {
-      for (let i = 0; i < props.activeBounds.length; i++) {
-        const boundName = props.activeBounds[i];
+      for (var i = 0; i < props.activeBounds.length; i++) {
+        var boundName = props.activeBounds[i];
         activateClass(boundName);
       }
     }
   }
 
   if (declaredClasses) {
-    for (let name in declaredClasses) {
-      let condition = declaredClasses[name];
+    for (var name in declaredClasses) {
+      var condition = declaredClasses[name];
 
       if (condition === true) {
         activateClass(name, { warn: true });

--- a/lib/merge-classes.js
+++ b/lib/merge-classes.js
@@ -1,1 +1,23 @@
-"use strict";var merge=require("merge"),isObject=require("lodash.isobject"),isArray=require("lodash.isarray");module.exports=function(e){return isObject(e)&&!isArray(e)?e:1===e.length?e[0]:merge.recursive.apply(void 0,e)};
+'use strict';
+
+var _this = this;
+
+const merge = require('merge');
+const isObject = require('lodash.isobject');
+const isArray = require('lodash.isarray');
+
+module.exports = thingsToBeMerged => {
+
+  // If its an object, lets just return it
+  if (isObject(thingsToBeMerged) && !isArray(thingsToBeMerged)) {
+    return thingsToBeMerged;
+  }
+
+  // If the array only has one object in it, return it
+  if (thingsToBeMerged.length === 1) {
+    return thingsToBeMerged[0];
+  }
+
+  // Else, lets just use the merge.js function:
+  return merge.recursive.apply(_this, thingsToBeMerged);
+};

--- a/lib/merge-classes.js
+++ b/lib/merge-classes.js
@@ -1,12 +1,10 @@
 'use strict';
 
-var _this = this;
+var merge = require('merge');
+var isObject = require('lodash.isobject');
+var isArray = require('lodash.isarray');
 
-const merge = require('merge');
-const isObject = require('lodash.isobject');
-const isArray = require('lodash.isarray');
-
-module.exports = thingsToBeMerged => {
+module.exports = function (thingsToBeMerged) {
 
   // If its an object, lets just return it
   if (isObject(thingsToBeMerged) && !isArray(thingsToBeMerged)) {
@@ -19,5 +17,5 @@ module.exports = thingsToBeMerged => {
   }
 
   // Else, lets just use the merge.js function:
-  return merge.recursive.apply(_this, thingsToBeMerged);
+  return merge.recursive.apply(undefined, thingsToBeMerged);
 };

--- a/lib/mixin.js
+++ b/lib/mixin.js
@@ -1,17 +1,17 @@
 'use strict';
 
-const React = require('react');
-const inline = require('./inline');
+var React = require('react');
+var inline = require('./inline');
 
 module.exports = {
   contextTypes: {
     mixins: React.PropTypes.object
   },
-  css(obj) {
+  css: function css(obj) {
     if (!this.classes) {
-      console.warn(`Define this.classes on \`${ this.constructor.name }\``);
+      console.warn('Define this.classes on `' + this.constructor.name + '`');
     }
-    const classes = typeof this.classes === 'function' ? this.classes() : {};
+    var classes = typeof this.classes === 'function' ? this.classes() : {};
 
     return inline(classes, this.props, this.context.mixins, obj);
   }

--- a/lib/mixin.js
+++ b/lib/mixin.js
@@ -3,8 +3,10 @@
 const React = require('react');
 const inline = require('./inline');
 
-class ReactCSSComponent extends React.Component {
-
+module.exports = {
+  contextTypes: {
+    mixins: React.PropTypes.object
+  },
   css(obj) {
     if (!this.classes) {
       console.warn(`Define this.classes on \`${ this.constructor.name }\``);
@@ -13,16 +15,4 @@ class ReactCSSComponent extends React.Component {
 
     return inline(classes, this.props, this.context.mixins, obj);
   }
-
-  styles() {
-    return this.css();
-  }
-
-}
-
-// For New Mixins
-ReactCSSComponent.contextTypes = {
-  mixins: React.PropTypes.object
 };
-
-module.exports = ReactCSSComponent;

--- a/lib/react-css.js
+++ b/lib/react-css.js
@@ -1,1 +1,8 @@
-"use strict";module.exports={Component:require("./Component"),inline:require("./inline"),mixin:{css:require("./inline")}};
+'use strict';
+
+module.exports = {
+  Component: require('./Component'),
+  useStyles: require('./use-styles'),
+  inline: require('./inline'),
+  mixin: require('./mixin')
+};

--- a/lib/transform-mixins.js
+++ b/lib/transform-mixins.js
@@ -1,16 +1,16 @@
 'use strict';
 
-const isObject = require('lodash.isobject');
-const isArray = require('lodash.isarray');
-const merge = require('merge');
+var isObject = require('lodash.isobject');
+var isArray = require('lodash.isarray');
+var merge = require('merge');
 
 /*
   Custom Props for the _mixins function
   These custom props will eventually live in a file or config somewhere
 */
 
-const localProps = {
-  userSelect: value => {
+var localProps = {
+  userSelect: function userSelect(value) {
     if (value !== null) {
       return {
         WebkitTouchCallout: value,
@@ -23,7 +23,7 @@ const localProps = {
     }
   },
 
-  flex: value => {
+  flex: function flex(value) {
     if (value !== null) {
       return {
         WebkitBoxFlex: value,
@@ -35,7 +35,7 @@ const localProps = {
     }
   },
 
-  flexBasis: value => {
+  flexBasis: function flexBasis(value) {
     if (value !== null) {
       return {
         WebkitFlexBasis: value,
@@ -44,7 +44,7 @@ const localProps = {
     }
   },
 
-  justifyContent: value => {
+  justifyContent: function justifyContent(value) {
     if (value !== null) {
       return {
         WebkitJustifyContent: value,
@@ -53,7 +53,7 @@ const localProps = {
     }
   },
 
-  transition: value => {
+  transition: function transition(value) {
     if (value !== null) {
       return {
         msTransition: value,
@@ -65,7 +65,7 @@ const localProps = {
     }
   },
 
-  transform: value => {
+  transform: function transform(value) {
     if (value !== null) {
       return {
         msTransform: value,
@@ -77,9 +77,9 @@ const localProps = {
     }
   },
 
-  Absolute: value => {
+  Absolute: function Absolute(value) {
     if (value !== null) {
-      const direction = value.split(" ");
+      var direction = value.split(" ");
       return {
         position: 'absolute',
         top: direction[0],
@@ -90,8 +90,8 @@ const localProps = {
     }
   },
 
-  Extend: (name, otherElementStyles) => {
-    const otherStyle = otherElementStyles[name];
+  Extend: function Extend(name, otherElementStyles) {
+    var otherStyle = otherElementStyles[name];
     if (otherStyle) {
       return otherStyle;
     }
@@ -99,10 +99,10 @@ const localProps = {
 
 };
 
-const transform = (styleObject, customFuncs, parent) => {
+var transform = function transform(styleObject, customFuncs, parent) {
 
-  const customProps = merge(customFuncs, localProps);
-  const obj = {};
+  var customProps = merge(customFuncs, localProps);
+  var obj = {};
 
   for (var key in styleObject) {
     var value = styleObject[key];
@@ -130,4 +130,6 @@ const transform = (styleObject, customFuncs, parent) => {
   return obj;
 };
 
-module.exports = (styleObject, customFuncs, parent) => transform(styleObject, customFuncs, parent);
+module.exports = function (styleObject, customFuncs, parent) {
+  return transform(styleObject, customFuncs, parent);
+};

--- a/lib/transform-mixins.js
+++ b/lib/transform-mixins.js
@@ -1,1 +1,133 @@
-"use strict";var isObject=require("lodash.isobject"),isArray=require("lodash.isarray"),merge=require("merge"),localProps={userSelect:function(r){return null!==r?{WebkitTouchCallout:r,KhtmlUserSelect:r,MozUserSelect:r,msUserSelect:r,WebkitUserSelect:r,userSelect:r}:void 0},flex:function(r){return null!==r?{WebkitBoxFlex:r,MozBoxFlex:r,WebkitFlex:r,msFlex:r,flex:r}:void 0},flexBasis:function(r){return null!==r?{WebkitFlexBasis:r,flexBasis:r}:void 0},justifyContent:function(r){return null!==r?{WebkitJustifyContent:r,justifyContent:r}:void 0},transition:function(r){return null!==r?{msTransition:r,MozTransition:r,OTransition:r,WebkitTransition:r,transition:r}:void 0},transform:function(r){return null!==r?{msTransform:r,MozTransform:r,OTransform:r,WebkitTransform:r,transform:r}:void 0},Absolute:function(r){if(null!==r){var e=r.split(" ");return{position:"absolute",top:e[0],right:e[1],bottom:e[2],left:e[3]}}},Extend:function(r,e){var t=e[r];return t?t:void 0}},transform=function r(e,t,n){var i=merge(t,localProps),o={};for(var s in e){var l=e[s];if(isObject(l)&&!isArray(l))o[s]=r(l,t,e);else if(i[s]){var u=i[s](l,n);for(var a in u){var f=u[a];o[a]=f}}else o[s]=l}return o};module.exports=function(r,e,t){return transform(r,e,t)};
+'use strict';
+
+const isObject = require('lodash.isobject');
+const isArray = require('lodash.isarray');
+const merge = require('merge');
+
+/*
+  Custom Props for the _mixins function
+  These custom props will eventually live in a file or config somewhere
+*/
+
+const localProps = {
+  userSelect: value => {
+    if (value !== null) {
+      return {
+        WebkitTouchCallout: value,
+        KhtmlUserSelect: value,
+        MozUserSelect: value,
+        msUserSelect: value,
+        WebkitUserSelect: value,
+        userSelect: value
+      };
+    }
+  },
+
+  flex: value => {
+    if (value !== null) {
+      return {
+        WebkitBoxFlex: value,
+        MozBoxFlex: value,
+        WebkitFlex: value,
+        msFlex: value,
+        flex: value
+      };
+    }
+  },
+
+  flexBasis: value => {
+    if (value !== null) {
+      return {
+        WebkitFlexBasis: value,
+        flexBasis: value
+      };
+    }
+  },
+
+  justifyContent: value => {
+    if (value !== null) {
+      return {
+        WebkitJustifyContent: value,
+        justifyContent: value
+      };
+    }
+  },
+
+  transition: value => {
+    if (value !== null) {
+      return {
+        msTransition: value,
+        MozTransition: value,
+        OTransition: value,
+        WebkitTransition: value,
+        transition: value
+      };
+    }
+  },
+
+  transform: value => {
+    if (value !== null) {
+      return {
+        msTransform: value,
+        MozTransform: value,
+        OTransform: value,
+        WebkitTransform: value,
+        transform: value
+      };
+    }
+  },
+
+  Absolute: value => {
+    if (value !== null) {
+      const direction = value.split(" ");
+      return {
+        position: 'absolute',
+        top: direction[0],
+        right: direction[1],
+        bottom: direction[2],
+        left: direction[3]
+      };
+    }
+  },
+
+  Extend: (name, otherElementStyles) => {
+    const otherStyle = otherElementStyles[name];
+    if (otherStyle) {
+      return otherStyle;
+    }
+  }
+
+};
+
+const transform = (styleObject, customFuncs, parent) => {
+
+  const customProps = merge(customFuncs, localProps);
+  const obj = {};
+
+  for (var key in styleObject) {
+    var value = styleObject[key];
+
+    // If its an object
+    if (isObject(value) && !isArray(value)) {
+      // Lets go ahead and run again
+      obj[key] = transform(value, customFuncs, styleObject);
+    } else {
+      // Check to see if a custom prop exists for it
+      if (customProps[key]) {
+        // let loop though and save the results from the function
+        var customResults = customProps[key](value, parent);
+        for (var customKey in customResults) {
+          var customValue = customResults[customKey];
+          obj[customKey] = customValue;
+        }
+      } else {
+        // If not, just copy it as-is
+        obj[key] = value;
+      }
+    }
+  }
+
+  return obj;
+};
+
+module.exports = (styleObject, customFuncs, parent) => transform(styleObject, customFuncs, parent);

--- a/lib/use-styles.js
+++ b/lib/use-styles.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const React = require('react');
+
+const inline = require('./inline');
+
+/*
+  Create a higher order Component that adds .css method (see Component.js) as a prop.
+
+  @param Component The component to add 'css(...)' to
+
+  @return          The component with 'css(...)' added
+ */
+module.exports = Compoent => {
+  return React.createClass({
+    displayName: `UseStyles_${ Compoent.displayName }`,
+
+    contextTypes: {
+      mixins: React.PropTypes.object
+    },
+
+    css(classes, declaredClasses) {
+      if (!classes) {
+        console.warn(`In \`${ Compoent.displayName }\`, this.props.css must be passed classes`);
+      };
+
+      return inline(classes, this.props, this.context.mixins, declaredClasses);
+    },
+
+    render() {
+      //return <Compoent {...this.props} css={this.css} />
+      // Not using ^ so babel-react doesn't need to be added
+
+      return React.createElement(Compoent, Object.assign({}, this.props, { css: this.css }));
+    }
+  });
+};

--- a/lib/use-styles.js
+++ b/lib/use-styles.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const React = require('react');
+var React = require('react');
 
-const inline = require('./inline');
+var inline = require('./inline');
 
 /*
   Create a higher order Component that adds .css method (see Component.js) as a prop.
@@ -11,23 +11,22 @@ const inline = require('./inline');
 
   @return          The component with 'css(...)' added
  */
-module.exports = Compoent => {
+module.exports = function (Compoent) {
   return React.createClass({
-    displayName: `UseStyles_${ Compoent.displayName }`,
+    displayName: 'UseStyles_' + Compoent.displayName,
 
     contextTypes: {
       mixins: React.PropTypes.object
     },
 
-    css(classes, declaredClasses) {
+    css: function css(classes, declaredClasses) {
       if (!classes) {
-        console.warn(`In \`${ Compoent.displayName }\`, this.props.css must be passed classes`);
+        console.warn('In `' + Compoent.displayName + '`, this.props.css must be passed classes');
       };
 
       return inline(classes, this.props, this.context.mixins, declaredClasses);
     },
-
-    render() {
+    render: function render() {
       //return <Compoent {...this.props} css={this.css} />
       // Not using ^ so babel-react doesn't need to be added
 

--- a/src/Component.js
+++ b/src/Component.js
@@ -11,7 +11,7 @@ class ReactCSSComponent extends React.Component {
     }
     const classes = typeof this.classes === 'function'? this.classes(): {}
 
-    return inline(classes, this.props, this.context, obj)
+    return inline(classes, this.props, this.context.mixins, obj)
   }
 
   styles() {

--- a/src/inline.js
+++ b/src/inline.js
@@ -6,26 +6,26 @@ let combine = require('./combine')
 
 /*
   Inline CSS function. This is the half-way point until multiple inheritance exists
+
+  @param classes: The classes to use
+  @param props: The props of the component the styles are being used by
+  @param context: The context of the component the styles are being used by
   @param declaredClasses: Object{ 'class-name': true / false }
+
   @returns object
 */
-
-module.exports = function (declaredClasses) {
+module.exports = (classes, props, context, declaredClasses) => {
   // What?
   combine = require('./combine')
 
   const arrayOfStyles = []
 
-  if (!this.classes) {
-    console.warn(`Define this.classes on \`${ this.constructor.name }\``)
-  }
-
   // Checks structure and warns if its odd
-  checkClassStructure(this.classes && this.classes())
+  checkClassStructure(classes)
 
   const activateClass = (name, options) => {
-    if (this.classes && this.classes()[name]) {
-      arrayOfStyles.push(this.classes()[name])
+    if (classes[name]) {
+      arrayOfStyles.push(classes[name])
     } else if (name && options && options.warn === true) {
       console.warn(`The \`${ name }\` css class does not exist on \`${ this.constructor.name }\``)
     }
@@ -33,8 +33,8 @@ module.exports = function (declaredClasses) {
 
   activateClass('default')
 
-  for (var prop in this.props) {
-    let value = this.props[prop]
+  for(var prop in props) {
+    let value = props[prop]
     if (!isObject(value)) {
 
       if (value === true) {
@@ -52,9 +52,9 @@ module.exports = function (declaredClasses) {
   // React Bounds
   // http://casesandberg.github.io/react-bounds/
   // Activate classes that match active bounds
-  if (this.props && this.props.activeBounds) {
-    for (var i = 0; i < this.props.activeBounds.length; i++) {
-      var boundName = this.props.activeBounds[i]
+  if (props && props.activeBounds) {
+    for (var i = 0; i < props.activeBounds.length; i++) {
+      var boundName = props.activeBounds[i]
       activateClass(boundName)
     }
   }
@@ -68,8 +68,8 @@ module.exports = function (declaredClasses) {
   }
 
   let customMixins = {}
-  if (this.context && this.context.mixins) {
-    customMixins = this.context.mixins
+  if (context && context.mixins) {
+    customMixins = context.mixins
   }
 
   return combine(arrayOfStyles, customMixins)

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -1,10 +1,8 @@
 'use strict'
 
-const React = require('react')
 const inline = require('./inline')
 
-class ReactCSSComponent extends React.Component {
-
+module.exports = {
   css(obj) {
     if (!this.classes) {
       console.warn(`Define this.classes on \`${ this.constructor.name }\``)
@@ -13,16 +11,4 @@ class ReactCSSComponent extends React.Component {
 
     return inline(classes, this.props, this.context, obj)
   }
-
-  styles() {
-    return this.css()
-  }
-
 }
-
-// For New Mixins
-ReactCSSComponent.contextTypes = {
-  mixins: React.PropTypes.object,
-}
-
-module.exports = ReactCSSComponent

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -1,14 +1,18 @@
 'use strict'
 
+const React = require('react')
 const inline = require('./inline')
 
 module.exports = {
+  contextTypes: {
+    mixins: React.PropTypes.object
+  },
   css(obj) {
     if (!this.classes) {
       console.warn(`Define this.classes on \`${ this.constructor.name }\``)
     }
     const classes = typeof this.classes === 'function'? this.classes(): {}
 
-    return inline(classes, this.props, this.context, obj)
+    return inline(classes, this.props, this.context.mixins, obj)
   }
 }

--- a/src/react-css.js
+++ b/src/react-css.js
@@ -4,7 +4,5 @@ module.exports = {
   Component: require('./Component'),
   useStyles: require('./use-styles'),
   inline: require('./inline'),
-  mixin: {
-    css: require('./inline'),
-  },
+  mixin: require('./mixin'),
 }

--- a/src/react-css.js
+++ b/src/react-css.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   Component: require('./Component'),
+  useStyles: require('./use-styles'),
   inline: require('./inline'),
   mixin: {
     css: require('./inline'),

--- a/src/use-styles.js
+++ b/src/use-styles.js
@@ -11,9 +11,9 @@ const inline = require('./inline')
 
   @return          The component with 'css(...)' added
  */
-module.exports = (Compoent) => {
+module.exports = (Component) => {
   return React.createClass({
-    displayName: `UseStyles_${Compoent.displayName}`,
+    displayName: `UseStyles_${Component.displayName}`,
 
     contextTypes: {
       mixins: React.PropTypes.object
@@ -21,18 +21,18 @@ module.exports = (Compoent) => {
 
     css(classes, declaredClasses) {
       if(!classes) {
-        console.warn(`In \`${ Compoent.displayName }\`, this.props.css must be passed classes`)
+        console.warn(`In \`${ Component.displayName }\`, this.props.css must be passed classes`)
       };
 
       return inline(classes, this.props, this.context.mixins, declaredClasses)
     },
 
     render() {
-      //return <Compoent {...this.props} css={this.css} />
+      //return <Component {...this.props} css={this.css} />
       // Not using ^ so babel-react doesn't need to be added
 
       return React.createElement(
-        Compoent,
+        Component,
         Object.assign({}, this.props, { css: this.css })
       )
     }

--- a/src/use-styles.js
+++ b/src/use-styles.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const React = require('react')
+
+const inline = require('./inline')
+
+/**
+ * Create a higher order Component that adds .css method (see Component.js) as a prop.
+ *
+ * @param Component The component to add 'css(..,)' to
+ *
+ * @return          The component with 'css(...)' added
+ */
+module.exports = (Compoent) => {
+  return React.createClass({
+    displayName: `UseStyles_${Compoent.displayName}`,
+
+    contextTypes: {
+      mixins: React.PropTypes.object
+    },
+
+    css(classes, declaredClasses) {
+      // Create inline function with dummy Component (that can return classes from a method)
+      const currInline = inline.bind({
+        props: this.props,
+        context: this.context,
+        classes() {
+          return classes
+        }
+      })
+
+      // Get styles
+      return currInline(declaredClasses)
+    },
+
+    render() {
+      return <Compoent {...this.props} css={this.css} />
+    }
+  })
+}

--- a/src/use-styles.js
+++ b/src/use-styles.js
@@ -22,9 +22,9 @@ module.exports = (Compoent) => {
     css(classes, declaredClasses) {
       if(!classes) {
         console.warn(`In \`${ Compoent.displayName }\`, this.props.css must be passed classes`)
-      }
+      };
 
-      return inline(classes? classes: {}, this.props, this.context, declaredClasses)
+      return inline(classes, this.props, this.context.mixins, declaredClasses)
     },
 
     render() {

--- a/src/use-styles.js
+++ b/src/use-styles.js
@@ -4,12 +4,12 @@ const React = require('react')
 
 const inline = require('./inline')
 
-/**
- * Create a higher order Component that adds .css method (see Component.js) as a prop.
- *
- * @param Component The component to add 'css(..,)' to
- *
- * @return          The component with 'css(...)' added
+/*
+  Create a higher order Component that adds .css method (see Component.js) as a prop.
+
+  @param Component The component to add 'css(...)' to
+
+  @return          The component with 'css(...)' added
  */
 module.exports = (Compoent) => {
   return React.createClass({
@@ -20,17 +20,11 @@ module.exports = (Compoent) => {
     },
 
     css(classes, declaredClasses) {
-      // Create inline function with dummy Component (that can return classes from a method)
-      const currInline = inline.bind({
-        props: this.props,
-        context: this.context,
-        classes() {
-          return classes
-        }
-      })
+      if(!classes) {
+        console.warn(`In \`${ Compoent.displayName }\`, this.props.css must be passed classes`)
+      }
 
-      // Get styles
-      return currInline(declaredClasses)
+      return inline(classes? classes: {}, this.props, this.context, declaredClasses)
     },
 
     render() {

--- a/src/use-styles.js
+++ b/src/use-styles.js
@@ -34,7 +34,13 @@ module.exports = (Compoent) => {
     },
 
     render() {
-      return <Compoent {...this.props} css={this.css} />
+      //return <Compoent {...this.props} css={this.css} />
+      // Not using ^ so babel-react doesn't need to be added
+
+      return React.createElement(
+        Compoent,
+        Object.assign({}, this.props, { css: this.css })
+      )
     }
   })
 }

--- a/test/inline.test.js
+++ b/test/inline.test.js
@@ -20,14 +20,12 @@ describe('React Inline', () => {
   // })
 
   it('return a css object from a set of true class names', function () {
-    this.classes = () => {
-      return {
-        'base': {
-          card: {
-            position: 'absolute',
-          },
+    const classes = {
+      'base': {
+        card: {
+          position: 'absolute',
         },
-      }
+      },
     }
 
     const before = {
@@ -40,28 +38,26 @@ describe('React Inline', () => {
       },
     }
 
-    expect(inline.call(this, before)).to.eql(after)
+    expect(inline(classes, {}, null, before)).to.eql(after)
   })
 
   it('return a css object from a bunch of class names', function () {
-    this.classes = () => {
-      return {
-        'base': {
-          card: {
-            position: 'absolute',
-          },
+    const classes = {
+      'base': {
+        card: {
+          position: 'absolute',
         },
-        'outlined': {
-          card: {
-            border: '2px solid #aeee00',
-          },
+      },
+      'outlined': {
+        card: {
+          border: '2px solid #aeee00',
         },
-        'disabled': {
-          card: {
-            display: 'none',
-          },
+      },
+      'disabled': {
+        card: {
+          display: 'none',
         },
-      }
+      },
     }
 
     const before = {
@@ -76,18 +72,16 @@ describe('React Inline', () => {
       },
     }
 
-    expect(inline.call(this, before)).to.eql(after)
+    expect(inline(classes, {}, null, before)).to.eql(after)
   })
 
   it('include the `default` class', function () {
-    this.classes = () => {
-      return {
-        'default': {
-          card: {
-            position: 'absolute',
-          },
+    const classes = {
+      'default': {
+        card: {
+          position: 'absolute',
         },
-      }
+      },
     }
 
     const after = {
@@ -96,33 +90,31 @@ describe('React Inline', () => {
       },
     }
 
-    expect(inline.call(this)).to.eql(after)
+    expect(inline(classes)).to.eql(after)
   })
 
   it('include any true props that match class names', function () {
-    this.props = {
+    const props = {
       isSelected: true,
       dark: true,
     }
-    this.classes = () => {
-      return {
-        'default': {
-          card: {
-            position: 'absolute',
-          },
+    const classes = {
+      'default': {
+        card: {
+          position: 'absolute',
         },
-        'isSelected': {
-          card: {
-            color: '#aeee00',
-            border: '2px solid #aeee00',
-          },
+      },
+      'isSelected': {
+        card: {
+          color: '#aeee00',
+          border: '2px solid #aeee00',
         },
-        'dark-true': {
-          card: {
-            color: '#333',
-          },
+      },
+      'dark-true': {
+        card: {
+          color: '#333',
         },
-      }
+      },
     }
 
     const after = {
@@ -133,32 +125,30 @@ describe('React Inline', () => {
       },
     }
 
-    expect(inline.call(this, before)).to.eql(after)
+    expect(inline(classes, props, null, before)).to.eql(after)
   })
 
   it('check if props and values match a class', function () {
-    this.props = {
+    const props = {
       isSelected: false,
       zDepth: 2,
     }
-    this.classes = () => {
-      return {
-        'default': {
-          card: {
-            position: 'absolute',
-          },
+    const classes = {
+      'default': {
+        card: {
+          position: 'absolute',
         },
-        'isSelected-false': {
-          card: {
-            background: 'grey',
-          },
+      },
+      'isSelected-false': {
+        card: {
+          background: 'grey',
         },
-        'zDepth-2': {
-          card: {
-            border: '2px solid #333',
-          },
+      },
+      'zDepth-2': {
+        card: {
+          border: '2px solid #333',
         },
-      }
+      },
     }
 
     const after = {
@@ -169,6 +159,6 @@ describe('React Inline', () => {
       },
     }
 
-    expect(inline.call(this, before)).to.eql(after)
+    expect(inline(classes, props, null, before)).to.eql(after)
   })
 })

--- a/test/mixin.test.js
+++ b/test/mixin.test.js
@@ -1,0 +1,85 @@
+'use strict'
+
+const React = require('react')
+const TestUtils = require('react-addons-test-utils')
+const expect = require('chai').expect
+require('testdom')('<html><body></body></html>')
+
+const mixin = require('../src/mixin');
+
+describe('mixin', function () {
+
+  it('should return simple css', function () {
+
+    const SomeComponent = React.createClass({
+
+      mixins: [ mixin ],
+
+      styles() {
+        return this.css()
+      },
+
+      classes() {
+        return {
+          'default': {
+            body: {
+              background: '#fafafa',
+            },
+          },
+        }
+      },
+
+      render() {
+        return React.createElement('div')
+      }
+    })
+
+    var someComponent = TestUtils.renderIntoDocument(React.createElement(SomeComponent, {}, 'baz'))
+
+    expect(someComponent.styles()).to.eql({
+      body: {
+        background: '#fafafa',
+      },
+    })
+  })
+
+  it('should return complex css', function () {
+
+    const SomeComponent = React.createClass({
+
+      mixins: [ mixin ],
+
+      styles() {
+        return this.css()
+      },
+
+      classes() {
+        return {
+          'default': {
+            title: {
+              color: this.props.color,
+            },
+            card: {
+              boxShadow: '0 0 2px rgba(0,0,0,.1)',
+            },
+          },
+        }
+      },
+
+      render() {
+        return React.createElement('div')
+      }
+    })
+
+    var someComponent = TestUtils.renderIntoDocument(React.createElement(SomeComponent, { color: 'red' }))
+
+    expect(someComponent.styles()).to.eql({
+      card: {
+        boxShadow: '0 0 2px rgba(0,0,0,.1)',
+      },
+      title: {
+        color: 'red',
+      },
+    })
+  })
+})

--- a/test/plugins/react-bounds.test.js
+++ b/test/plugins/react-bounds.test.js
@@ -8,28 +8,26 @@ describe('Plugins', () => {
   describe('React Bounds', () => {
 
     it('Activates class names if active bound name matches', function () {
-      this.props = {
+      const props = {
         activeBounds: ['some-bound', 'really-large'],
       }
 
-      this.classes = () => {
-        return {
-          'default': {
-            wrap: {
-              position: 'relative',
-            },
+      const classes = {
+        'default': {
+          wrap: {
+            position: 'relative',
           },
-          'some-bound': {
-            wrap: {
-              color: '#333',
-            },
+        },
+        'some-bound': {
+          wrap: {
+            color: '#333',
           },
-          'really-large': {
-            wrap: {
-              fontSize: '24px',
-            },
+        },
+        'really-large': {
+          wrap: {
+            fontSize: '24px',
           },
-        }
+        },
       }
 
       const after = {
@@ -40,7 +38,7 @@ describe('Plugins', () => {
         },
       }
 
-      expect(inline.call(this)).to.eql(after)
+      expect(inline(classes, props)).to.eql(after)
     })
   })
 })

--- a/test/use-styles.test.js
+++ b/test/use-styles.test.js
@@ -14,7 +14,7 @@ describe('useStyles', function () {
     class SomeComponent extends React.Component {
 
       styles() {
-        return this.props.css(this.classes());
+        return this.props.css(this.classes())
       }
 
       classes() {
@@ -48,7 +48,7 @@ describe('useStyles', function () {
     class SomeComponent extends React.Component {
 
       styles() {
-        return this.props.css(this.classes());
+        return this.props.css(this.classes())
       }
 
       classes() {

--- a/test/use-styles.test.js
+++ b/test/use-styles.test.js
@@ -1,0 +1,85 @@
+'use strict'
+
+const React = require('react')
+const TestUtils = require('react-addons-test-utils')
+const expect = require('chai').expect
+require('testdom')('<html><body></body></html>')
+
+const useStyles = require('../src/use-styles');
+
+describe('useStyles', function () {
+
+  it('should return simple css', function () {
+
+    class SomeComponent extends React.Component {
+
+      styles() {
+        return this.props.css(this.classes());
+      }
+
+      classes() {
+        return {
+          'default': {
+            body: {
+              background: '#fafafa',
+            },
+          },
+        }
+      }
+
+      render() {
+        return React.createElement('div')
+      }
+    }
+    var StyledComponent = useStyles(SomeComponent);
+
+    var styledComponent = TestUtils.renderIntoDocument(React.createElement(StyledComponent, {}, 'baz'))
+    var someComponent = TestUtils.findRenderedComponentWithType(styledComponent, SomeComponent)
+
+    expect(someComponent.styles()).to.eql({
+      body: {
+        background: '#fafafa',
+      },
+    })
+  })
+
+  it('should return complex css', function () {
+
+    class SomeComponent extends React.Component {
+
+      styles() {
+        return this.props.css(this.classes());
+      }
+
+      classes() {
+        return {
+          'default': {
+            title: {
+              color: this.props.color,
+            },
+            card: {
+              boxShadow: '0 0 2px rgba(0,0,0,.1)',
+            },
+          },
+        }
+      }
+
+      render() {
+        return React.createElement('div')
+      }
+    }
+    var StyledComponent = useStyles(SomeComponent);
+
+    var styledComponent = TestUtils.renderIntoDocument(React.createElement(StyledComponent, { color: 'red' }))
+    var someComponent = TestUtils.findRenderedComponentWithType(styledComponent, SomeComponent)
+
+    expect(someComponent.styles()).to.eql({
+      card: {
+        boxShadow: '0 0 2px rgba(0,0,0,.1)',
+      },
+      title: {
+        color: 'red',
+      },
+    })
+  })
+})


### PR DESCRIPTION
I've added a Higher 0rder Component, to help close #32.

The HOC is in the 'src/use-styles.js' file and expoted as ```useStyles(...)```. It is almost the same as the [gist](https://gist.github.com/nheyn/ac4f4200313fd34d81ee) I brought up in the issue. The main difference is I got rid of the 'hack'.

Todo that, the ```inline(...)``` function was change. It now takes the data it needs from the component as arguments, instead of binding the component to the function.

There is also a new 'src/mixin.js' file, that contains the exported react mixin. It seemed to make sense now that ```inline(...)``` could not simply be set as the ```css(...)``` method.

Tests have been created/updated for the new code/changes to ```inline(...)```. Examples have been added to the 'examples/' directory.