### PR TITLE
Add React 15 to supported versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lodash.isarray": "^4.0.0",
     "lodash.isobject": "^3.0.2",
     "merge": "^1.2.0",
-    "react": "^0.14.0"
+    "react": "^0.14.0 || ^15.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.6.4",
@@ -49,7 +49,7 @@
     "mocha": "^2.2.1",
     "mocha-sinon": "^1.1.5",
     "normalize.css": "^3.0.3",
-    "react-addons-test-utils": "^0.14.0",
+    "react-addons-test-utils": "^0.14.0 || ^15.0.0",
     "react-hot-loader": "^1.2.5",
     "react-map-styles": "git://github.com/casesandberg/react-map-styles",
     "remarkable": "^1.6.0",


### PR DESCRIPTION
I know you've got greenkeeper pull requests for these, but I suspect they're failing because you need to upgrade `react` and `react-addons-test-utils` together.  I bumped these, ran tests and tried them out in our application and everything seems good-to-go without further changes.

I've simply expanded your version range for now, since nothing else changed so we're clearly not deprecating support for React 0.14.x.