### PR TITLE
Remove react-addons-test-utils from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,7 @@
   },
   "peerDependencies": {
     "react": "^0.14.8 || ^15.1.0",
-    "react-dom": "^0.14.8 || ^15.1.0",
-    "react-addons-test-utils": "^0.14.8 || ^15.1.0"
+    "react-dom": "^0.14.8 || ^15.1.0"
   },
   "scripts": {
     "lib": "gulp js:dist",


### PR DESCRIPTION
Remove react-addons-test-utils from peerDependencies since it is only… needed in the devDependencies. This gets rid of a pesky warning message during npm install...