### PR TITLE
Optional default property

### DIFF
--- a/src/mergeClasses.js
+++ b/src/mergeClasses.js
@@ -1,7 +1,13 @@
 import _ from 'lodash'
 
 export const mergeClasses = (classes, activeNames = []) => {
+
+  if(!classes.default && activeNames.length === 0){
+    classes = { default: classes }
+  }
+  
   const styles = (classes.default && _.cloneDeep(classes.default)) || {}
+  
   activeNames.map((name) => {
     const toMerge = classes[name]
     if (toMerge) {

--- a/test/mergeClasses.test.js
+++ b/test/mergeClasses.test.js
@@ -129,3 +129,41 @@ describe('Combine', () => {
     expect(mergeClasses(classes, [])).toEqual(after2)
   })
 })
+
+describe('Combine with optional default ', () => {
+  it('should assume all properties are under the default property when "default" is omitted with no activeNames', () => {
+    const classes = {
+      header: {
+        margin: '0px',
+      },
+      logo: {
+        color: 'blue',
+      },
+    }
+    const after = {
+      header: {
+        margin: '0px',
+      },
+      logo: {
+        color: 'blue',
+      },
+    }
+    expect(mergeClasses(classes)).toEqual(after)
+  })
+
+  it('should not assume properties are nested under default when "default" is omitted but activeNames are present', () => {
+    const classes = {
+      header: {
+        margin: '0px',
+      },
+      logo: {
+        color: 'blue',
+      },
+    }
+    const after = {}
+
+    const names = ['active']
+
+    expect(mergeClasses(classes, names)).toEqual(after)
+  })
+})


### PR DESCRIPTION
For those of us coming from a React Native background, having to specify a "default" property on declarations where we don't have any active names is like nails on chalkboard. This is a backwards compatible tweak that makes specifying the "default" property optional when no activeNames are specified. Basically, it allows this:

```javascript
import ReactCSS from 'reactcss'

const styleObj = {
   logo: {
     color: 'blue'
   },
   header: {
      backgroundColor: 'black'
   } 
}

const styles = ReactCSS(styleObj)

console.log(
  _.isEqual(styleObj, styles) // outputs true
) 

```

This is far more ergonomic for my use case in which I plan to basically never use activeNames.

Are you okay with this change? It is backwards compatible, but would you prefer maybe a separate named export to expose this functionality? That would also work. 

