### PR TITLE
fix: add missing peer dependency react

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   "dependencies": {
     "lodash": "^4.0.1"
   },
+  "peerDependencies": {
+    "react": "*"
+  },
   "devDependencies": {
     "@case/eslint-config": "^0.1.4",
     "babel": "^6.0.15",


### PR DESCRIPTION
**What's the problem this PR addresses?**

`reactcss` is trying to use `react` without declaring it as a peer dependency

**How did you fix it?**

Added `react` to peer dependencies